### PR TITLE
Remove italics from some operators

### DIFF
--- a/themes/dark.codely-theme-color-theme.json
+++ b/themes/dark.codely-theme-color-theme.json
@@ -1283,6 +1283,19 @@
 			"settings": {
 				"foreground": "#8EC07C"
 			}
+		},
+		{
+			"name": "Operators without italics",
+			"scope": [
+				"keyword.operator.assignment",
+				"keyword.operator.bitwise",
+				"keyword.operator.type",
+				"keyword.operator.logical",
+				"keyword.operator.arithmetic"
+			],
+			"settings": {
+				"fontStyle": ""
+			}
 		}
 	]
 }


### PR DESCRIPTION
This Pull Request introduces a change to the theme configuration setup to remove the use of italics for specific operators. These operators include the type assignment colon (`:`), the value assignment equal sign (`=`), and logical operators (e.g., `&&`, `||`, `!`, etc.).

The purpose of this change is to improve the readability and consistency of the code, as some users find italics difficult to read or distracting. Additionally, removing italics from these operators aligns with common style guides and conventions, allowing for a more uniform experience across various projects.

The modifications include updates to the theme's JSON file, specifically in the `tokenColors` array where each operator's styling is defined. The `fontStyle` property for these operators has been updated to exclude the "italic" value.

Summary of changes:

- Update theme configuration file to remove italics from type assignment colon
- Remove italics from value assignment equal sign
- Eliminate italics from logical operators

This Pull Request may be considered somewhat opinionated, as the choice of using italics for specific operators is often a matter of personal preference. However, I believe that this change can provide a net positive impact on the readability and consistency of the code for the majority of our team members. To help illustrate the differences and potential benefits, I have included before and after screenshots to showcase the updated theme configuration:

**Before**

![CleanShot 2023-04-29 at 02 23 43@2x](https://user-images.githubusercontent.com/9295713/235272839-008bdf00-37c7-4f12-ad13-9264da877882.png)

---

**After**

![CleanShot 2023-04-29 at 02 24 43@2x](https://user-images.githubusercontent.com/9295713/235272826-52dae2d5-00d9-41b1-9552-887200b7eb00.png)

Thanks in advance!
